### PR TITLE
Solve the problem of incorrect jumping of secondary menu.

### DIFF
--- a/config/routes.ts
+++ b/config/routes.ts
@@ -24,7 +24,6 @@
     name: 'admin',
     icon: 'crown',
     access: 'canAdmin',
-    component: './Admin',
     routes: [
       {
         path: '/admin/sub-page',


### PR DESCRIPTION
Solve the problem of incorrect jumping of secondary menu.
Menu items that contain secondary menus should not have components of their own, which would cause the secondary menu to not jump correctly. For first time users, this is a difficult problem to troubleshoot.